### PR TITLE
Update jekyll-commonmark.gemspec to address CVE-2022-39209

### DIFF
--- a/jekyll-commonmark.gemspec
+++ b/jekyll-commonmark.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.6.0"
 
-  spec.add_runtime_dependency "commonmarker", "~> 0.23.4"
+  spec.add_runtime_dependency "commonmarker", "~> 0.23.6"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "jekyll", ">= 3.7", "< 5.0"


### PR DESCRIPTION
Update to commonmarker 0.23.6 to address CVE-2022-39209